### PR TITLE
Add TCP and TCP_SSL Support to the runtime.

### DIFF
--- a/src/main/scala/psync/runtime/PacketServer.scala
+++ b/src/main/scala/psync/runtime/PacketServer.scala
@@ -16,9 +16,6 @@ abstract class PacketServer(
 
   def defaultHandler(pkt: DatagramPacket): Unit
 
-  protected var chan: Channel = null
-  def channel: Channel = chan
-
   val dispatcher = new InstanceDispatcher(options)
 
   def close: Unit

--- a/src/main/scala/psync/runtime/PacketServer.scala
+++ b/src/main/scala/psync/runtime/PacketServer.scala
@@ -6,7 +6,7 @@ import io.netty.channel.socket.DatagramPacket
 
 abstract class PacketServer(
     executor: java.util.concurrent.Executor,
-    ports: Iterable[Int],
+    port: Int,
     initGroup: Group,
     _defaultHandler: Message => Unit, //defaultHandler is responsible for releasing the ByteBuf payload
     options: RuntimeOptions)
@@ -16,8 +16,8 @@ abstract class PacketServer(
 
   def defaultHandler(pkt: DatagramPacket): Unit
 
-  protected var chans: Array[Channel] = null
-  def channels: Array[Channel] = chans
+  protected var chan: Channel = null
+  def channel: Channel = chan
 
   val dispatcher = new InstanceDispatcher(options)
 

--- a/src/main/scala/psync/runtime/PacketServer.scala
+++ b/src/main/scala/psync/runtime/PacketServer.scala
@@ -1,20 +1,8 @@
 package psync.runtime
 
 import psync._
-import dzufferey.utils.Logger
-import dzufferey.utils.LogLevel._
-
-import io.netty.buffer._
-import io.netty.channel._
-import io.netty.channel.socket._
-import io.netty.channel.nio._
-import io.netty.channel.socket.nio._
-import io.netty.channel.epoll._
-import io.netty.channel.oio._
-import io.netty.channel.socket.oio._
-import io.netty.channel.ChannelHandler.Sharable
-import io.netty.bootstrap.Bootstrap
-import java.net.InetSocketAddress
+import io.netty.channel.Channel
+import io.netty.channel.socket.DatagramPacket
 
 abstract class PacketServer(
     executor: java.util.concurrent.Executor,

--- a/src/main/scala/psync/runtime/PacketServer.scala
+++ b/src/main/scala/psync/runtime/PacketServer.scala
@@ -16,7 +16,7 @@ import io.netty.channel.ChannelHandler.Sharable
 import io.netty.bootstrap.Bootstrap
 import java.net.InetSocketAddress
 
-class PacketServer(
+abstract class PacketServer(
     executor: java.util.concurrent.Executor,
     ports: Iterable[Int],
     initGroup: Group,
@@ -26,82 +26,15 @@ class PacketServer(
 
   val directory = new Directory(initGroup)
 
-  def defaultHandler(pkt: DatagramPacket) {
-    val msg = new Message(pkt, directory.group)
-    _defaultHandler(msg)
-  }
+  def defaultHandler(pkt: DatagramPacket): Unit
 
-  Logger.assert(options.protocol == NetworkProtocol.UDP, "PacketServer", "transport layer: only UDP supported for the moment")
-
-  private val group: EventLoopGroup = options.group match {
-    case NetworkGroup.NIO => new NioEventLoopGroup()
-    case NetworkGroup.OIO => new OioEventLoopGroup()
-    case NetworkGroup.EPOLL => new EpollEventLoopGroup()
-  }
-
-  private var chans: Array[Channel] = null
+  protected var chans: Array[Channel] = null
   def channels: Array[Channel] = chans
 
   val dispatcher = new InstanceDispatcher(options)
 
-  def close {
-    dispatcher.clear
-    try {
-      group.shutdownGracefully
-    } finally {
-      for ( i <- chans.indices) {
-        if (chans(i) != null) {
-          chans(i).close
-          chans(i) = null
-        }
-      }
-    }
-  }
+  def close: Unit
 
-  def start {
-    val packetSize = options.packetSize
-    val b = new Bootstrap()
-    b.group(group)
-    options.group match {
-      case NetworkGroup.NIO =>   b.channel(classOf[NioDatagramChannel])
-      case NetworkGroup.OIO =>   b.channel(classOf[OioDatagramChannel])
-      case NetworkGroup.EPOLL => b.channel(classOf[EpollDatagramChannel])
-    }
-
-    if (packetSize >= 8) {//make sure we have at least space for the tag
-      b.option[Integer](ChannelOption.SO_RCVBUF, packetSize)
-      b.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(packetSize))
-    }
-
-    b.handler(new PackerServerHandler(defaultHandler, dispatcher))
-
-    val ps = ports.toArray
-    chans = ps.map( p => b.bind(p).sync().channel() )
-  }
+  def start: Unit
 
 }
-
-@Sharable
-class PackerServerHandler(
-    defaultHandler: DatagramPacket => Unit,
-    dispatcher: InstanceDispatcher
-  ) extends SimpleChannelInboundHandler[DatagramPacket](false) {
-
-  //in Netty version 5.0 will be called: channelRead0 will be messageReceived
-  override def channelRead0(ctx: ChannelHandlerContext, pkt: DatagramPacket) {
-    try {
-    if (!dispatcher.dispatch(pkt))
-      defaultHandler(pkt) 
-    } catch {
-      case t: Throwable =>
-        Logger("PacketServerHandler", Warning, "got " + t)
-    }
-  }
-
-  override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
-    cause.printStackTrace()
-  }
-
-}
-
-

--- a/src/main/scala/psync/runtime/PacketServer.scala
+++ b/src/main/scala/psync/runtime/PacketServer.scala
@@ -25,4 +25,6 @@ abstract class PacketServer(
 
   def start: Unit
 
+  def send(pkt: DatagramPacket): Unit
+
 }

--- a/src/main/scala/psync/runtime/Runtime.scala
+++ b/src/main/scala/psync/runtime/Runtime.scala
@@ -110,7 +110,12 @@ class Runtime[IO,P <: Process[IO]](val alg: Algorithm[IO,P],
       else Set(options.port)
     val port = ports.iterator.next()
     Logger("Runtime", Info, "starting service on ports: " + ports.mkString(", "))
-    val pktSrv = new UDPPacketServer(executor, port, grp, defaultHandler, options)
+    val pktSrv = options.protocol match {
+      case NetworkProtocol.UDP =>
+        new UDPPacketServer(executor, port, grp, defaultHandler, options)
+      case _ =>
+        new TCPPacketServer(executor, port, grp, defaultHandler, options)
+    }
     srv = Some(pktSrv)
     pktSrv.start
     for (i <- 0 until options.processPool) processPool.offer(createProcess)

--- a/src/main/scala/psync/runtime/Runtime.scala
+++ b/src/main/scala/psync/runtime/Runtime.scala
@@ -36,10 +36,9 @@ class Runtime[IO,P <: Process[IO]](val alg: Algorithm[IO,P],
     assert(srv.isDefined)
     val p = alg.process
     p.setOptions(options)
-    val channel = srv.get.channel
     val dispatcher = srv.get.dispatcher
     val defaultHandler = srv.get.defaultHandler(_)
-    new InstanceHandler(p, this, channel, dispatcher, defaultHandler, options)
+    new InstanceHandler(p, this, srv.get, dispatcher, defaultHandler, options)
   }
 
   private def getProcess: InstanceHandler[IO,P] = {
@@ -153,9 +152,7 @@ class Runtime[IO,P <: Process[IO]](val alg: Algorithm[IO,P],
       } else {
         new DatagramPacket(payload, dst)
       }
-    val channel = srv.get.channel
-    channel.write(pkt, channel.voidPromise())
-    channel.flush
+    srv.get.send(pkt)
   }
 
   def directory = {

--- a/src/main/scala/psync/runtime/Runtime.scala
+++ b/src/main/scala/psync/runtime/Runtime.scala
@@ -27,7 +27,7 @@ class Runtime[IO,P <: Process[IO]](val alg: Algorithm[IO,P],
       val w = n
       Logger("Runtime", Debug, "using fixed thread pool of size " + w)
       java.util.concurrent.Executors.newFixedThreadPool(w)
-    case Adapt => 
+    case Adapt =>
       Logger("Runtime", Debug, "using cached thread pool")
       java.util.concurrent.Executors.newCachedThreadPool()
   }
@@ -104,17 +104,17 @@ class Runtime[IO,P <: Process[IO]](val alg: Algorithm[IO,P],
       //already running
       return
     }
-    
+
     //create the group
     val me = new ProcessID(options.id)
     val grp = Group(me, options.peers)
 
     //start the server
-    val ports = 
+    val ports =
       if (grp contains me) grp.get(me).ports
       else Set(options.port)
     Logger("Runtime", Info, "starting service on ports: " + ports.mkString(", "))
-    val pktSrv = new PacketServer(executor, ports, grp, defaultHandler, options)
+    val pktSrv = new UDPPacketServer(executor, ports, grp, defaultHandler, options)
     srv = Some(pktSrv)
     pktSrv.start
     for (i <- 0 until options.processPool) processPool.offer(createProcess)
@@ -130,7 +130,7 @@ class Runtime[IO,P <: Process[IO]](val alg: Algorithm[IO,P],
     }
     srv = None
   }
-  
+
   def submitTask(fct: Runnable) = {
     executor.execute(fct)
   }

--- a/src/main/scala/psync/runtime/RuntimeOptions.scala
+++ b/src/main/scala/psync/runtime/RuntimeOptions.scala
@@ -11,7 +11,7 @@ object NetworkGroup extends Enumeration {
 
 object NetworkProtocol extends Enumeration {
   type NetworkProtocol = Value
-  val UDP, TCP = Value
+  val UDP, TCP, TCP_SSL = Value
 }
 
 sealed abstract class Workers
@@ -20,7 +20,7 @@ case class Fixed(nbr: Int) extends Workers
 case class Factor(coeff: Int) extends Workers
 
 trait RuntimeOptions {
-  
+
   def id = _id
   def peers = _peers
   def group = _group
@@ -58,14 +58,14 @@ trait RuntimeOptions {
 abstract class RTOptions extends DefaultOptions with RuntimeOptions {
 
   import dzufferey.arg._
-  
+
   newOption("--conf",                   String( s => processConFile(s)),            "configuration file")
   newOption("-id",                      Int( i => _id = i.toShort),                 "the replica ID")
   newOption("--id",                     Int( i => _id = i.toShort),                 "the replica ID")
   newOption("--group",                  Enum(NetworkGroup, (s: NetworkGroup.NetworkGroup) => _group = s),
                                                                                     "the network layer interface used by Netty: NIO/OIO/EPOLL (default: NIO).")
   newOption("--protocol",               Enum(NetworkProtocol, (s: NetworkProtocol.NetworkProtocol) => _protocol = s),
-                                                                                    "the network protocol: UDP/TCP (default: UDP).")
+                                                                                    "the network protocol: UDP/TCP/TCP_SSL (default: UDP).")
   newOption("-to",                      Int( i => _timeout = i.toLong ),            "default timeout for runtime (default: 10).")
   newOption("--timeout",                Int( i => _timeout = i.toLong ),            "default timeout for runtime (default: 10).")
   newOption("--earlyMoving",            Bool( b => _earlyMoving = b ),              "early moving optimization (default: true).")
@@ -100,7 +100,7 @@ abstract class RTOptions extends DefaultOptions with RuntimeOptions {
     } catch {
       case e: Exception =>
         Logger("RuntimeOptions", Warning, "size of pool of workers has wrong format, using adaptative")
-        Adapt 
+        Adapt
     }
   }
 

--- a/src/main/scala/psync/runtime/TCPPacketServer.scala
+++ b/src/main/scala/psync/runtime/TCPPacketServer.scala
@@ -1,0 +1,100 @@
+package psync.runtime
+
+import psync._
+import dzufferey.utils.Logger
+import dzufferey.utils.LogLevel._
+
+import io.netty.buffer._
+import io.netty.channel._
+import io.netty.channel.socket._
+import io.netty.channel.nio._
+import io.netty.channel.socket.nio._
+import io.netty.channel.epoll._
+import io.netty.channel.oio._
+import io.netty.channel.socket.oio._
+import io.netty.channel.ChannelHandler.Sharable
+import io.netty.bootstrap.Bootstrap
+import java.net.InetSocketAddress
+
+class TCPPacketServer(
+    executor: java.util.concurrent.Executor,
+    ports: Iterable[Int],
+    initGroup: Group,
+    _defaultHandler: Message => Unit, //defaultHandler is responsible for releasing the ByteBuf payload
+    options: RuntimeOptions) extends PacketServer(executor, ports, initGroup, _defaultHandler, options)
+{
+
+  def defaultHandler(pkt: DatagramPacket) {
+    val msg = new Message(pkt, directory.group)
+    _defaultHandler(msg)
+  }
+
+  Logger.assert(options.protocol == NetworkProtocol.TCP, "TCPPacketServer", "transport layer: only TCP supported for the moment")
+
+  private val group: EventLoopGroup = options.group match {
+    case NetworkGroup.NIO => new NioEventLoopGroup()
+    case NetworkGroup.OIO => new OioEventLoopGroup()
+    case NetworkGroup.EPOLL => new EpollEventLoopGroup()
+  }
+
+  def close {
+    dispatcher.clear
+    try {
+      group.shutdownGracefully
+    } finally {
+      for ( i <- chans.indices) {
+        if (chans(i) != null) {
+          chans(i).close
+          chans(i) = null
+        }
+      }
+    }
+  }
+
+  def start {
+    val packetSize = options.packetSize
+    val b = new Bootstrap()
+    b.group(group)
+    options.group match {
+      case NetworkGroup.NIO =>   b.channel(classOf[NioDatagramChannel])
+      case NetworkGroup.OIO =>   b.channel(classOf[OioDatagramChannel])
+      case NetworkGroup.EPOLL => b.channel(classOf[EpollDatagramChannel])
+    }
+
+    if (packetSize >= 8) {//make sure we have at least space for the tag
+      b.option[Integer](ChannelOption.SO_RCVBUF, packetSize)
+      b.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(packetSize))
+    }
+
+    b.handler(new TCPPacketServerHandler(defaultHandler, dispatcher))
+
+    val ps = ports.toArray
+    chans = ps.map( p => b.bind(p).sync().channel() )
+  }
+
+}
+
+@Sharable
+class TCPPacketServerHandler(
+    defaultHandler: DatagramPacket => Unit,
+    dispatcher: InstanceDispatcher
+  ) extends SimpleChannelInboundHandler[DatagramPacket](false) {
+
+  //in Netty version 5.0 will be called: channelRead0 will be messageReceived
+  override def channelRead0(ctx: ChannelHandlerContext, pkt: DatagramPacket) {
+    try {
+    if (!dispatcher.dispatch(pkt))
+      defaultHandler(pkt)
+    } catch {
+      case t: Throwable =>
+        Logger("TCPPacketServerHandler", Warning, "got " + t)
+    }
+  }
+
+  override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
+    cause.printStackTrace()
+  }
+
+}
+
+

--- a/src/main/scala/psync/runtime/TCPPacketServer.scala
+++ b/src/main/scala/psync/runtime/TCPPacketServer.scala
@@ -1,9 +1,11 @@
 package psync.runtime
 
 import psync._
+import psync.utils.Timer
 import dzufferey.utils.Logger
 import dzufferey.utils.LogLevel._
 
+import io.netty.bootstrap._
 import io.netty.buffer._
 import io.netty.channel._
 import io.netty.channel.socket._
@@ -13,8 +15,11 @@ import io.netty.channel.epoll._
 import io.netty.channel.oio._
 import io.netty.channel.socket.oio._
 import io.netty.channel.ChannelHandler.Sharable
-import io.netty.bootstrap.Bootstrap
+import io.netty.handler.ssl._
+import io.netty.handler.ssl.util._
 import java.net.InetSocketAddress
+import java.util.concurrent.{Executors, TimeUnit}
+import scala.collection.mutable.{Map, SynchronizedMap, HashMap}
 
 class TCPPacketServer(
     executor: java.util.concurrent.Executor,
@@ -24,82 +29,193 @@ class TCPPacketServer(
     options: RuntimeOptions) extends PacketServer(executor, port, initGroup, _defaultHandler, options)
 {
 
-  private var recipientMap: Map[ProcessID, Channel] = Map()
+  val recipientMap: Map[ProcessID, Channel] = new HashMap[ProcessID, Channel] with SynchronizedMap[ProcessID, Channel]
+  private val recipients: Set[ProcessID] = initGroup.replicas.map(_.id).toSet - initGroup.self
 
   def defaultHandler(pkt: DatagramPacket) {
     val msg = new Message(pkt, directory.group)
     _defaultHandler(msg)
   }
 
-  Logger.assert(options.protocol == NetworkProtocol.TCP, "TCPPacketServer", "transport layer: only TCP supported")
+  Logger.assert(options.protocol == NetworkProtocol.TCP || options.protocol == NetworkProtocol.TCP_SSL,
+                "TCPPacketServer", "transport layer: only TCP supported")
 
-  private val group: EventLoopGroup = options.group match {
-    case NetworkGroup.NIO => new NioEventLoopGroup()
-    case NetworkGroup.OIO => new OioEventLoopGroup()
-    case NetworkGroup.EPOLL => new EpollEventLoopGroup()
-  }
+  private val isSSLEnabled = (options.protocol == NetworkProtocol.TCP_SSL)
+
+  private val sslServerCtx = if (isSSLEnabled) {
+    val ssc = new SelfSignedCertificate()
+    SslContextBuilder.forServer(ssc.certificate(), ssc.privateKey()).build();
+  } else null
+
+  private val sslClientCtx = if (isSSLEnabled) {
+    SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build();
+  } else null
+
+  private val group: EventLoopGroup = new NioEventLoopGroup()
+
+  private val connectionRestartPeriod = 250
 
   def close {
-    // dispatcher.clear
-    // try {
-    //   group.shutdownGracefully
-    // } finally {
-    //   chan.close()
-    //   chan = null
-    // }
+    dispatcher.clear
+    try {
+      group.shutdownGracefully
+    } finally {
+      recipientMap.foreach {
+        case (pid, channel) =>
+          channel.close()
+      }
+    }
+  }
+
+  val outerThis = this
+
+  def startListener() {
+    val bootstrap = new ServerBootstrap()
+    bootstrap.group(group)
+    bootstrap.channel(classOf[NioServerSocketChannel])
+    bootstrap.childHandler(new ChannelInitializer[SocketChannel] {
+      override def initChannel(ch: SocketChannel) {
+        val pipeline = ch.pipeline()
+        if (isSSLEnabled) {
+          pipeline.addLast(sslServerCtx.newHandler(ch.alloc()))
+        }
+        pipeline.addLast(new TCPPacketServerHandler(outerThis))
+      }
+    })
+    bootstrap.bind(port).sync()
+  }
+
+  def delayedStartConnction(id: ProcessID) {
+    if (group.isShuttingDown())
+      return
+    val loop = group.next()
+    loop.schedule(new Runnable() {
+      override def run() {
+        startConnection(id)
+      }
+    }, connectionRestartPeriod, TimeUnit.MILLISECONDS)
+  }
+
+  def startConnection(id: ProcessID) {
+    val bootstrap = new Bootstrap()
+    val inet = initGroup.idToInet(id)
+    bootstrap.group(group)
+    bootstrap.channel(classOf[NioSocketChannel])
+    bootstrap.handler(new ChannelInitializer[SocketChannel] {
+      override def initChannel(ch: SocketChannel) {
+        val pipeline = ch.pipeline()
+        if (isSSLEnabled) {
+          pipeline.addLast(sslClientCtx.newHandler(ch.alloc(), inet.getHostName(), inet.getPort()))
+        }
+        pipeline.addLast(new TCPPacketClientHandler(outerThis, id))
+      }
+    })
+    bootstrap.connect(inet).addListener(new ChannelFutureListener() {
+      override def operationComplete(future: ChannelFuture) {
+        if (future.cause() != null) {
+          Logger("TCPPacketServer", Debug, "Couldn't connect, trying again...")
+          delayedStartConnction(id)
+        }
+      }
+    })
   }
 
   def start {
-    // val packetSize = options.packetSize
-    // val b = new Bootstrap()
-    // b.group(group)
-    // options.group match {
-    //   case NetworkGroup.NIO =>   b.channel(classOf[NioDatagramChannel])
-    //   case NetworkGroup.OIO =>   b.channel(classOf[OioDatagramChannel])
-    //   case NetworkGroup.EPOLL => b.channel(classOf[EpollDatagramChannel])
-    // }
-
-    // if (packetSize >= 8) {//make sure we have at least space for the tag
-    //   b.option[Integer](ChannelOption.SO_RCVBUF, packetSize)
-    //   b.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(packetSize))
-    // }
-
-    // b.handler(new TCPPacketServerHandler(defaultHandler, dispatcher))
-
-    // chan = b.bind(port).sync().channel()
+    startListener()
+    recipients.foreach { recipient =>
+      if (initGroup.self.id < recipient.id)
+        startConnection(recipient)
+    }
   }
 
   def send(pkt: DatagramPacket) {
     val recipientAddress = pkt.recipient
     val recipientID = initGroup.get(recipientAddress).id
-    val chan = recipientMap(recipientID)
-    chan.write(pkt, chan.voidPromise())
-    chan.flush
+    val chanOption = recipientMap.get(recipientID)
+    chanOption match {
+      case Some(chan) =>
+        chan.write(pkt.content, chan.voidPromise())
+        chan.flush
+      case None =>
+        Logger("TCPPacketServer", Warning, "Tried to send packet, but no channel was available.")
+        // Todo: have some sort of queue that waits for the client to come back up?
+        //       Drop the packet?
+    }
   }
 
-}
-
-@Sharable
-class TCPPacketServerHandler(
-    defaultHandler: DatagramPacket => Unit,
-    dispatcher: InstanceDispatcher
-  ) extends SimpleChannelInboundHandler[DatagramPacket](false) {
-
-  //in Netty version 5.0 will be called: channelRead0 will be messageReceived
-  override def channelRead0(ctx: ChannelHandlerContext, pkt: DatagramPacket) {
+  def receive(process: ProcessID, buf: ByteBuf) {
+    val inet = initGroup.idToInet(process)
+    val src = initGroup.idToInet(initGroup.self)
+    val pkt = new DatagramPacket(buf, src, inet)
     try {
-    if (!dispatcher.dispatch(pkt))
-      defaultHandler(pkt)
+      if (!dispatcher.dispatch(pkt))
+        defaultHandler(pkt)
     } catch {
       case t: Throwable =>
         Logger("TCPPacketServerHandler", Warning, "got " + t)
     }
   }
 
+}
+
+class TCPPacketServerHandler(
+    packetServer: TCPPacketServer
+  ) extends SimpleChannelInboundHandler[ByteBuf](false) {
+
+  var processID: Option[ProcessID] = None
+
+  override def channelActive(ctx: ChannelHandlerContext) {
+    Logger("TCPPacketServerHandler", Debug, "Someone connected.")
+  }
+
+  override def channelInactive(ctx: ChannelHandlerContext) {
+    Logger("TCPPacketServerHandler", Debug, "Someone disconneted")
+    if (processID.isDefined)
+      packetServer.recipientMap.remove(processID.get)
+  }
+
+  override def channelRead0(ctx: ChannelHandlerContext, buf: ByteBuf) {
+    if (processID.isEmpty) {
+      // First message is always a processID
+      processID = Some(new ProcessID(buf.getShort(0)))
+      packetServer.recipientMap.update(processID.get, ctx.channel())
+    } else {
+      packetServer.receive(processID.get, buf)
+    }
+  }
+
   override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
     cause.printStackTrace()
   }
-
 }
 
+class TCPPacketClientHandler(
+    packetServer: TCPPacketServer,
+    processID: ProcessID
+  ) extends SimpleChannelInboundHandler[ByteBuf](false) {
+
+  override def channelRead0(ctx: ChannelHandlerContext, buf: ByteBuf) {
+    packetServer.receive(processID, buf)
+  }
+
+  override def channelActive(ctx: ChannelHandlerContext) {
+    Logger("TCPPacketClientHandler", Debug, "Someone connected.")
+    val chan = ctx.channel()
+    packetServer.recipientMap.update(processID, chan)
+    val payload = PooledByteBufAllocator.DEFAULT.buffer()
+    payload.writeShort(processID.id)
+    chan.write(payload, chan.voidPromise())
+    chan.flush
+  }
+
+  override def channelInactive(ctx: ChannelHandlerContext) {
+    Logger("TCPPacketClientHandler", Debug, "Someone disconneted")
+    packetServer.recipientMap.remove(processID)
+    packetServer.delayedStartConnction(processID)
+  }
+
+  override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
+    cause.printStackTrace()
+  }
+}
 

--- a/src/main/scala/psync/runtime/TCPPacketServer.scala
+++ b/src/main/scala/psync/runtime/TCPPacketServer.scala
@@ -67,6 +67,11 @@ class TCPPacketServer(
     chan = b.bind(port).sync().channel()
   }
 
+  def send(pkt: DatagramPacket) {
+    chan.write(pkt, channel.voidPromise())
+    chan.flush
+  }
+
 }
 
 @Sharable

--- a/src/main/scala/psync/runtime/UDPPacketServer.scala
+++ b/src/main/scala/psync/runtime/UDPPacketServer.scala
@@ -24,6 +24,9 @@ class UDPPacketServer(
     options: RuntimeOptions) extends PacketServer(executor, port, initGroup, _defaultHandler, options)
 {
 
+  protected var chan: Channel = null
+  def channel: Channel = chan
+
   def defaultHandler(pkt: DatagramPacket) {
     val msg = new Message(pkt, directory.group)
     _defaultHandler(msg)
@@ -67,7 +70,7 @@ class UDPPacketServer(
   }
 
   def send(pkt: DatagramPacket) {
-    chan.write(pkt, channel.voidPromise())
+    chan.write(pkt, chan.voidPromise())
     chan.flush
   }
 

--- a/src/main/scala/psync/runtime/UDPPacketServer.scala
+++ b/src/main/scala/psync/runtime/UDPPacketServer.scala
@@ -1,0 +1,100 @@
+package psync.runtime
+
+import psync._
+import dzufferey.utils.Logger
+import dzufferey.utils.LogLevel._
+
+import io.netty.buffer._
+import io.netty.channel._
+import io.netty.channel.socket._
+import io.netty.channel.nio._
+import io.netty.channel.socket.nio._
+import io.netty.channel.epoll._
+import io.netty.channel.oio._
+import io.netty.channel.socket.oio._
+import io.netty.channel.ChannelHandler.Sharable
+import io.netty.bootstrap.Bootstrap
+import java.net.InetSocketAddress
+
+class UDPPacketServer(
+    executor: java.util.concurrent.Executor,
+    ports: Iterable[Int],
+    initGroup: Group,
+    _defaultHandler: Message => Unit, //defaultHandler is responsible for releasing the ByteBuf payload
+    options: RuntimeOptions) extends PacketServer(executor, ports, initGroup, _defaultHandler, options)
+{
+
+  def defaultHandler(pkt: DatagramPacket) {
+    val msg = new Message(pkt, directory.group)
+    _defaultHandler(msg)
+  }
+
+  Logger.assert(options.protocol == NetworkProtocol.UDP, "UDPPacketServer", "transport layer: only UDP supported for the moment")
+
+  private val group: EventLoopGroup = options.group match {
+    case NetworkGroup.NIO => new NioEventLoopGroup()
+    case NetworkGroup.OIO => new OioEventLoopGroup()
+    case NetworkGroup.EPOLL => new EpollEventLoopGroup()
+  }
+
+  def close {
+    dispatcher.clear
+    try {
+      group.shutdownGracefully
+    } finally {
+      for ( i <- chans.indices) {
+        if (chans(i) != null) {
+          chans(i).close
+          chans(i) = null
+        }
+      }
+    }
+  }
+
+  def start {
+    val packetSize = options.packetSize
+    val b = new Bootstrap()
+    b.group(group)
+    options.group match {
+      case NetworkGroup.NIO =>   b.channel(classOf[NioDatagramChannel])
+      case NetworkGroup.OIO =>   b.channel(classOf[OioDatagramChannel])
+      case NetworkGroup.EPOLL => b.channel(classOf[EpollDatagramChannel])
+    }
+
+    if (packetSize >= 8) {//make sure we have at least space for the tag
+      b.option[Integer](ChannelOption.SO_RCVBUF, packetSize)
+      b.option(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(packetSize))
+    }
+
+    b.handler(new UDPPacketServerHandler(defaultHandler, dispatcher))
+
+    val ps = ports.toArray
+    chans = ps.map( p => b.bind(p).sync().channel() )
+  }
+
+}
+
+@Sharable
+class UDPPacketServerHandler(
+    defaultHandler: DatagramPacket => Unit,
+    dispatcher: InstanceDispatcher
+  ) extends SimpleChannelInboundHandler[DatagramPacket](false) {
+
+  //in Netty version 5.0 will be called: channelRead0 will be messageReceived
+  override def channelRead0(ctx: ChannelHandlerContext, pkt: DatagramPacket) {
+    try {
+    if (!dispatcher.dispatch(pkt))
+      defaultHandler(pkt)
+    } catch {
+      case t: Throwable =>
+        Logger("UDPPacketServerHandler", Warning, "got " + t)
+    }
+  }
+
+  override def exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
+    cause.printStackTrace()
+  }
+
+}
+
+

--- a/src/main/scala/psync/runtime/UDPPacketServer.scala
+++ b/src/main/scala/psync/runtime/UDPPacketServer.scala
@@ -66,6 +66,11 @@ class UDPPacketServer(
     chan = b.bind(port).sync().channel()
   }
 
+  def send(pkt: DatagramPacket) {
+    chan.write(pkt, channel.voidPromise())
+    chan.flush
+  }
+
 }
 
 @Sharable


### PR DESCRIPTION
This PR adds TCP and TCP_SSL support to the Psync runtime.

TCP is pretty self explanatory, but TCP_SSL adds a layer of self-signed certificates on top of the TCP. What this can guarantee us is that once a session has been established between the nodes, no tampering can occur over the wire, even with an active adversary. In addition, a passive adversary is unable to see the contents of messages sent between nodes.

Even with TCP_SSL, however, an active adversary can still MITM nodes when connections are being established!
# Code changes

This refactors the PacketServer class into two subclasses: TCPPacketServer and UDPPacketServer. All sending and receiving of packets are done via the send and recv methods of these classes.
# Some benchmarks (higher throughput is better):
## UDP

``` sh
$ ./test_scripts/testLV.sh -to 5
running 3 LV replicas for 60 seconds
stopping ...
#instances = 323978, Δt = 60, throughput = 5399
#instances = 323660, Δt = 60, throughput = 5394
#instances = 325042, Δt = 60, throughput = 5417
```
## TCP

``` sh
$ ./test_scripts/testLV.sh -to 5
running 3 LV replicas for 60 seconds
stopping ...
#instances = 487879, Δt = 59, throughput = 8269
#instances = 499356, Δt = 59, throughput = 8463
#instances = 499694, Δt = 59, throughput = 8469
```
## TCP_SSL

``` sh
$ ./test_scripts/testLV.sh -to 5
running 3 LV replicas for 60 seconds
stopping ...
#instances = 150414, Δt = 58, throughput = 2593
#instances = 142063, Δt = 58, throughput = 2449
#instances = 150699, Δt = 58, throughput = 2598
```

As you can see, sometimes the TCP stack outperforms the UDP slack, but SSL incurs a high performance penalty. One explanation for TCP outperforming UDP may lie in the way netty handles each stack. Also, these gains in performance may not be realized over a connection with any sort of delay - these tests were running on localhost.
